### PR TITLE
Use pwsh shebang, and Add-Type over LoadFile

### DIFF
--- a/Invoke-MDFHashes/Get-MDFHashes.ps1
+++ b/Invoke-MDFHashes/Get-MDFHashes.ps1
@@ -1,9 +1,8 @@
-﻿# Created by XPN (xpn.github.io)
-
+#!/usr/bin/pwsh
 
 Try {
-    [Reflection.Assembly]::LoadFile($currentLocation.Path + "\\OrcaMDF.RawCore.dll") | Out-Null
-    [Reflection.Assembly]::LoadFile($currentLocation.Path + "\\OrcaMDF.Framework.dll") | Out-NUll
+    Add-Type -AssemblyName .\OrcaMDF.RawCore.dll
+    Add-Type -AssemblyName .\OrcaMDF.Framework.dll
 } Catch {
     Write-Host "Could not load OrcaMDF libraries, please make sure that you run Import-Module from the dir containing OrcaMDF.RawCore.dll and OrcaMDF.Framework.dll"
 }


### PR DESCRIPTION
This PR mixes two things that perhaps ought not to be:

- use a pwsh shebang, for Unix compat (using e.g. https://github.com/PowerShell/powershell/releases)
- for loading .dll's, use Add-Type over LoadFile.

Again, might serve better as two commits, but eh.